### PR TITLE
Horizontal bar plot support and spanish translation

### DIFF
--- a/wagtail_plotly/blocks/base.py
+++ b/wagtail_plotly/blocks/base.py
@@ -3,6 +3,7 @@ import plotly.graph_objects as go
 
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core import blocks
 from wagtail_json_widget.blocks import JSONBlock
@@ -15,19 +16,20 @@ from ..config import (
 )
 
 from ..utils import (
-    get_layout, 
-    get_config, 
-    get_trace, 
+    get_layout,
+    get_config,
+    get_trace,
     get_layout_choices
 )
 
 
 class BasePlotBlock(blocks.StructBlock):
 
-    title = blocks.CharBlock(required=False)
-    xaxis_title = blocks.CharBlock(required=False)
-    yaxis_title = blocks.CharBlock(required=False)
-    graph_layout = blocks.ChoiceBlock(required=False, choices=get_layout_choices)
+    title = blocks.CharBlock(label=_('Title'), required=False)
+    xaxis_title = blocks.CharBlock(label=_('X axis title'), required=False)
+    yaxis_title = blocks.CharBlock(label=_('Y axis title'), required=False)
+    graph_layout = blocks.ChoiceBlock(
+        label=_('Graph layout'), required=False, choices=get_layout_choices)
 
     def get_rows(self, plot_data):
         """

--- a/wagtail_plotly/blocks/base.py
+++ b/wagtail_plotly/blocks/base.py
@@ -5,7 +5,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.core import blocks
+from wagtail import blocks
 from wagtail_json_widget.blocks import JSONBlock
 
 from ..config import (

--- a/wagtail_plotly/blocks/blocks.py
+++ b/wagtail_plotly/blocks/blocks.py
@@ -2,7 +2,7 @@ import plotly.graph_objects as go
 
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.core import blocks
+from wagtail import blocks
 
 from ..config import (
     DEFAULT_BAR_TABLE_OPTIONS,

--- a/wagtail_plotly/blocks/blocks.py
+++ b/wagtail_plotly/blocks/blocks.py
@@ -17,13 +17,16 @@ from .table import (
 
 from .base import BasePlotBlock, CustomPlotMixin
 
-from ..utils import to_float
+from ..utils import to_float, get_orientation_choices
 
 
 class BarChartBlock(BasePlotBlock):
     """
     Base bar chart block
     """
+    orientation = blocks.ChoiceBlock(required=True, default='v',
+        choices=get_orientation_choices)
+
     plot_data = PlotDataBlock(
         table_options=DEFAULT_BAR_TABLE_OPTIONS,
         help_text=(
@@ -41,6 +44,9 @@ class BarChartBlock(BasePlotBlock):
         # Get the data in column format from the table
         columns = self.get_columns(value['plot_data'])
 
+        # Get plot orientation, either horizontal or vertical
+        orientation = value.get('orientation', 'v')
+
         if len(columns) >= 2:
             # Pop the first column for common x values
             x_vals = columns.pop(0)[1:]
@@ -50,11 +56,11 @@ class BarChartBlock(BasePlotBlock):
                 y = column[1:]
 
                 # Handle horizontal bars by swapping x and y
-                if value.get('orientation') == 'h':
+                if orientation == 'h':
                     x, y = y, x
 
                 data.append(
-                    go.Bar(name=column[0], x=x, y=y)
+                    go.Bar(name=column[0], x=x, y=y, orientation=orientation)
                 )
         return data
 

--- a/wagtail_plotly/blocks/blocks.py
+++ b/wagtail_plotly/blocks/blocks.py
@@ -1,5 +1,7 @@
 import plotly.graph_objects as go
 
+from django.utils.translation import gettext_lazy as _
+
 from wagtail.core import blocks
 
 from ..config import (
@@ -24,13 +26,14 @@ class BarChartBlock(BasePlotBlock):
     """
     Base bar chart block
     """
-    orientation = blocks.ChoiceBlock(required=True, default='v',
-        choices=get_orientation_choices)
+    orientation = blocks.ChoiceBlock(label=_('Orientation'), required=True,
+        default='v', choices=get_orientation_choices)
 
     plot_data = PlotDataBlock(
         table_options=DEFAULT_BAR_TABLE_OPTIONS,
-        help_text=(
-            'Bar plot data with a set of common X values and multiple sets of Y values. '
+        help_text=_(
+            'Bar plot data with a set of common X values' +
+            ' and multiple sets of Y values. ' +
             'First row contains Name(s) for legend.'
         ),
     )
@@ -73,8 +76,9 @@ class ContourPlotBlock(BasePlotBlock):
 
     plot_data = PlotDataBlock(
         table_options=DEFAULT_CONTOUR_TABLE_OPTIONS,
-        help_text=(
-            'Contour plot data with X and Y dimensions, with a grid of values representing Z'
+        help_text=_(
+            'Contour plot data with X and Y dimensions,' +
+            ' with a grid of values representing Z'
         ),
     )
 
@@ -165,9 +169,9 @@ class LinePlotBlock(BasePlotBlock):
     """
     plot_data = PlotDataBlock(
         table_options=DEFAULT_LINE_TABLE_OPTIONS,
-        help_text=(
-            'Line plot data with a set of common X values and multiple sets of Y values. '
-            'First row contains Name(s) for legend.'
+        help_text=_(
+            'Line plot data with a set of common X values and multiple sets' +
+            ' of Y values. First row contains Name(s) for legend.'
         ),
     )
 
@@ -200,9 +204,7 @@ class PieChartBlock(BasePlotBlock):
 
     plot_data = PlotDataBlock(
         table_options=DEFAULT_PIE_TABLE_OPTIONS,
-        help_text=(
-            'Pie chart data with a set of name and value columns.'
-        ),
+        help_text=_('Pie chart data with a set of name and value columns.'),
     )
 
     def build_data(self, value):
@@ -230,9 +232,9 @@ class ScatterPlotBlock(BasePlotBlock):
     """
     plot_data = PlotDataBlock(
         table_options=DEFAULT_SCATTER_TABLE_OPTIONS,
-        help_text=(
-            'Scatter plot data with multiple sets of X and Y values (X0, Y0), (X1, Y1) etc. '
-            'First row contains Name(s) for legend.'
+        help_text=_(
+            'Scatter plot data with multiple sets of X and Y values' +
+            ' (X0, Y0), (X1, Y1) etc. First row contains Name(s) for legend.'
         ),
     )
 
@@ -264,9 +266,9 @@ class DotPlotBlock(BasePlotBlock):
     """
     plot_data = PlotDataBlock(
         table_options=DEFAULT_DOT_TABLE_OPTIONS,
-        help_text=(
-            'Dot plot data with a set of common Y values and multiple sets of X values. '
-            'First row contains Name(s) for legend.'
+        help_text=_(
+            'Dot plot data with a set of common Y values and multiple sets' +
+            ' of X values. First row contains Name(s) for legend.'
         ),
     )
 

--- a/wagtail_plotly/blocks/table.py
+++ b/wagtail_plotly/blocks/table.py
@@ -8,9 +8,9 @@ from wagtail.contrib.table_block.blocks import (
     TableBlock,
     TableInput,
 )
-from wagtail.core import blocks
-from wagtail.core.telepath import register
-from wagtail.core.widget_adapters import WidgetAdapter
+from wagtail import blocks
+from wagtail.telepath import register
+from wagtail.widget_adapters import WidgetAdapter
 
 
 from ..config import (

--- a/wagtail_plotly/blocks/table.py
+++ b/wagtail_plotly/blocks/table.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.contrib.table_block.blocks import (
@@ -78,11 +78,11 @@ class BubblePlotDataBlock(blocks.StructBlock):
     """
     Bubble plot data block
     """
-    group_name = blocks.CharBlock(help_text='Name of the bubble group')
+    group_name = blocks.CharBlock(help_text=_('Name of the bubble group'))
 
     plot_data = PlotDataBlock(
         table_options=DEFAULT_BUBBLE_TABLE_OPTIONS,
         help_text=(
-            'Bubble plot data with Name, X, Y and Z values.'
+            _('Bubble plot data with Name, X, Y and Z values.')
         ),
     )

--- a/wagtail_plotly/locale/es/LC_MESSAGES/django.po
+++ b/wagtail_plotly/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,109 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-03-29 18:10+0100\n"
+"PO-Revision-Date: 2023-03-29 18:14+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+
+#: apps.py:8
+msgid "Wagtail Plotly"
+msgstr "Wagtail Plotly"
+
+#: blocks/base.py:28
+msgid "Title"
+msgstr "Título"
+
+#: blocks/base.py:29
+msgid "X axis title"
+msgstr "Título eje X"
+
+#: blocks/base.py:30
+msgid "Y axis title"
+msgstr "Título eje Y"
+
+#: blocks/base.py:32
+msgid "Graph layout"
+msgstr "Disposición de la gráfica"
+
+#: blocks/blocks.py:29
+msgid "Orientation"
+msgstr "Orientación"
+
+#: blocks/blocks.py:35
+msgid ""
+"Bar plot data with a set of common X values and multiple sets of Y values. "
+"First row contains Name(s) for legend."
+msgstr ""
+"Gráfico de barras de datos con un conjunto de valores X comunes y múltiples "
+"conjuntos de valores Y. La primera fila contiene el nombre(s) de la leyenda."
+
+#: blocks/blocks.py:80
+msgid ""
+"Contour plot data with X and Y dimensions, with a grid of values "
+"representing Z"
+msgstr ""
+"Gráfico de contorno de datos con dimensiones X e Y, con una cuadrícula de "
+"valores que representan Z"
+
+#: blocks/blocks.py:173
+msgid ""
+"Line plot data with a set of common X values and multiple sets of Y values. "
+"First row contains Name(s) for legend."
+msgstr ""
+"Gráfico de barras de datos con un conjunto de valores X comunes y múltiples "
+"conjuntos de valores Y. La primera fila contiene el nombre(s) de la leyenda."
+
+#: blocks/blocks.py:207
+msgid "Pie chart data with a set of name and value columns."
+msgstr ""
+"Datos del gráfico circular con un conjunto de columnas de nombre y valor."
+
+#: blocks/blocks.py:236
+msgid ""
+"Scatter plot data with multiple sets of X and Y values (X0, Y0), (X1, Y1) "
+"etc. First row contains Name(s) for legend."
+msgstr ""
+"Datos de gráfico de dispersión con múltiples conjuntos de valores X e Y "
+"(X0, Y0), (X1, Y1), etc. La primera fila contiene el nombre(s) de la "
+"leyenda."
+
+#: blocks/blocks.py:270
+msgid ""
+"Dot plot data with a set of common Y values and multiple sets of X values. "
+"First row contains Name(s) for legend."
+msgstr ""
+"Gráfico de barras de datos con un conjunto de valores X comunes y múltiples "
+"conjuntos de valores Y. La primera fila contiene el nombre(s) de la leyenda."
+
+#: blocks/table.py:42
+msgid "Table"
+msgstr "Tabla"
+
+#: blocks/table.py:81
+msgid "Name of the bubble group"
+msgstr "Nombre del grupo de burbuja"
+
+#: blocks/table.py:86
+msgid "Bubble plot data with Name, X, Y and Z values."
+msgstr "Datos del gráfico de burbujas con los valores nombre, X, Y y Z."
+
+#: utils.py:71
+msgid "Vertical"
+msgstr "Vertical"
+
+#: utils.py:71
+msgid "Horizontal"
+msgstr "Horizontal"

--- a/wagtail_plotly/utils.py
+++ b/wagtail_plotly/utils.py
@@ -3,6 +3,7 @@ import os
 from collections import namedtuple
 
 from django.apps import apps
+from django.utils.translation import gettext_lazy as _
 
 from .config import PLOTLY_FIGURE_DIRECTORY
 
@@ -28,7 +29,7 @@ def get_layout_data(dir):
         path = os.path.join(dir, file)
         with open(path) as f:
             yield file, json.load(f)
-    
+
 Layout = namedtuple("Layout", "name layout")
 
 def get_layouts():
@@ -67,4 +68,4 @@ def get_layout_choices():
     return choices
 
 def get_orientation_choices():
-    return [('v', 'Vertical'), ('h', 'Horizontal')]
+    return [('v', _('Vertical')), ('h', _('Horizontal'))]

--- a/wagtail_plotly/utils.py
+++ b/wagtail_plotly/utils.py
@@ -66,3 +66,5 @@ def get_layout_choices():
         choices.append((layout.name, layout.name))
     return choices
 
+def get_orientation_choices():
+    return [('v', 'Vertical'), ('h', 'Horizontal')]


### PR DESCRIPTION
Hello,

As the subject implies, I added support for horizontal bar plots. The user can select now the orientation from the wagtail admin on a plot basis.

I checked if it would make sense to add the orientation option also for the other plots, except Pie, Surface, and Heatmap that do not have that option. But, it would require to push up the JS and Python libraries as it requires the 'scattermode' option in Plotly. And besides, you can create a scatter with the Y label as strings already, even without changing the orientation.

I also added Spanish translation strings.

Cheers.